### PR TITLE
fix: convert calendar descriptions from HTML to markdown

### DIFF
--- a/bot/cogs/calendar.py
+++ b/bot/cogs/calendar.py
@@ -11,8 +11,19 @@ import logging
 import traceback
 import icalendar
 import recurring_ical_events
+from markdownify import MarkdownConverter
 from discord.ext import commands, tasks
 from discord import EntityType, PrivacyLevel
+
+
+class ParagraphConverter(MarkdownConverter):
+    def convert_p(self, el, text, convert_as_inline):
+        """Change parsing of p tag to have only one newline isntead of 2"""
+        return super().convert_p(el, text, convert_as_inline)[:-1]
+
+
+def md(html, **options):
+    return ParagraphConverter(**options).convert(html)
 
 
 class Calendar(commands.Cog, name="calendar"):
@@ -51,7 +62,7 @@ class Calendar(commands.Cog, name="calendar"):
                     continue
 
                 # Fill in missing keys
-                description = str(event.get("DESCRIPTION", ""))
+                description = md(str(event.get("DESCRIPTION", "")))
                 location = str(event.get("LOCATION", ""))
 
                 for scheduled_event in scheduled_events:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The official StudSec bot written in Python"
 license = "GPL-3.0-only"
 authors = [
     "Robert Klink <roberthklink@gmail.com>",
-    "Aidan <aidands@protonmail.com>"
+    "Aidan <aidands@protonmail.com>",
 ]
 
 [tool.poetry.dependencies]
@@ -20,6 +20,7 @@ requests = "^2.31.0"
 datetime = "^5.4"
 icalendar = "^5.0.11"
 recurring-ical-events = "^2.1.2"
+markdownify = "^0.13.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Simple quick fix using `markdownify` to convert possible HTML descriptions to markdown. Some duplicate code but that can be addressed later with a rework to these two calendar modules.